### PR TITLE
Ability to set base point and display count of dark tiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build
 # other
 eclipse
 run
+/nbproject/private/
+/.nb-gradle/

--- a/manifest.mf
+++ b/manifest.mf
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+X-COMMENT: Main-Class will be added automatically by build
+

--- a/src/main/java/com/mmyzd/llor/ConfigManager.java
+++ b/src/main/java/com/mmyzd/llor/ConfigManager.java
@@ -16,6 +16,8 @@ public class ConfigManager {
 	public Property displayMode;
 	public Property chunkRadius;
 	public Property pollingInterval;
+	public Property focusCoordinate;
+	public Property showClosest;
 	public ArrayList<String> displayModeName = new ArrayList<String>();
 	public ArrayList<String> displayModeDesc = new ArrayList<String>();
 	
@@ -47,6 +49,8 @@ public class ConfigManager {
 		displayMode = file.get("general", "displayMode", 0, comment);
 		chunkRadius = file.get("general", "chunkRadius", 3, "The distance (in chunks) of rendering radius. (default: 3)");
 		pollingInterval = file.get("general", "pollingInterval", 200, "The update interval (in milliseconds) of light level. Farther chunks update less frequently. (default: 200)");
+		focusCoordinate = file.get("general", "focusCoordinate", "", "If given, the calculation will start at this coordinate instead of the players position.");
+		showClosest = file.get("general", "showClosest", false, "Give directions to the closest tile with a light level below 8.");
 		update();
 	}
 	
@@ -55,6 +59,8 @@ public class ConfigManager {
 		displayMode.set(Math.min(Math.max(displayMode.getInt(0), 0), displayModeName.size() - 1));
 		chunkRadius.set(Math.min(Math.max(chunkRadius.getInt(3), 1), 9));
 		pollingInterval.set(Math.min(Math.max(pollingInterval.getInt(200), 10), 60000));
+		focusCoordinate.set(focusCoordinate.getString());
+		showClosest.set(showClosest.getBoolean(false));
 		file.save();
 	}
 	

--- a/src/main/java/com/mmyzd/llor/LightLevelOverlayReloaded.java
+++ b/src/main/java/com/mmyzd/llor/LightLevelOverlayReloaded.java
@@ -21,6 +21,7 @@ import org.lwjgl.input.Keyboard;
 public class LightLevelOverlayReloaded {
 
 	public static final String MODID = "llor";
+	private static final int TICKS_FOR_MESSAGE = 40;
 
 	@Instance(MODID)
 	public static LightLevelOverlayReloaded instance;
@@ -73,12 +74,12 @@ public class LightLevelOverlayReloaded {
 				boolean useSkyLight = !config.useSkyLight.getBoolean();
 				config.useSkyLight.set(useSkyLight);
 				message = "Light Level Overlay: " + (useSkyLight ? "Block Light + Sky Light" : "Block Light Only");
-				messageRemainingTicks = 40;
+				messageRemainingTicks = TICKS_FOR_MESSAGE;
 			} else if (active && withCtrl && !withShift) {
 				int mode = (config.displayMode.getInt() + 1) % 3;
 				config.displayMode.set(mode);
 				message = "Light Level Overlay: " + config.displayModeName.get(mode) + " Mode";
-				messageRemainingTicks = 40;
+				messageRemainingTicks = TICKS_FOR_MESSAGE;
 			} else if (active && withCtrl && withShift) {
 				if(config.focusCoordinate.getString() == null || config.focusCoordinate.getString().isEmpty()) {
 					Minecraft mc = Minecraft.getMinecraft();
@@ -89,12 +90,12 @@ public class LightLevelOverlayReloaded {
 					config.focusCoordinate.set(focusCoordinate);
 					config.showClosest.set(true);
 					message = "Light Level Overlay: Focus on: " + focusCoordinate;
-					messageRemainingTicks = 40;
+					messageRemainingTicks = TICKS_FOR_MESSAGE;
 				} else {
 					config.focusCoordinate.set("");
 					config.showClosest.set(false);
 					message = "Light Level Overlay: Focus on: player";
-					messageRemainingTicks = 40;
+					messageRemainingTicks = TICKS_FOR_MESSAGE;
 				}
 			} else if (!withShift && !withCtrl && !withAlt) {
 				active = !active;
@@ -122,6 +123,13 @@ public class LightLevelOverlayReloaded {
 			messageRemainingTicks -= event.getPartialTicks();
 			event.getLeft().add(message);
 		}
+		
+		if(LightLevelOverlayReloaded.instance.config.showClosest.getBoolean()) {
+			StringBuilder messageB = new StringBuilder("");
+			for(int ii = 0; ii < poller.counts.length; ii++) {
+				messageB.append(ii).append(": ").append(poller.counts[ii]).append(" -- ");
+			}
+			event.getRight().add(messageB.toString());
+		}
 	}
-
 }

--- a/src/main/java/com/mmyzd/llor/LightLevelOverlayReloaded.java
+++ b/src/main/java/com/mmyzd/llor/LightLevelOverlayReloaded.java
@@ -79,6 +79,23 @@ public class LightLevelOverlayReloaded {
 				config.displayMode.set(mode);
 				message = "Light Level Overlay: " + config.displayModeName.get(mode) + " Mode";
 				messageRemainingTicks = 40;
+			} else if (active && withCtrl && withShift) {
+				if(config.focusCoordinate.getString() == null || config.focusCoordinate.getString().isEmpty()) {
+					Minecraft mc = Minecraft.getMinecraft();
+					int playerPosY = (int)Math.floor(mc.player.posY);
+					int playerPosX = (int)Math.floor(mc.player.posX);
+					int playerPosZ = (int)Math.floor(mc.player.posZ); 
+					String focusCoordinate = playerPosX + "," + playerPosY + "," + playerPosZ;
+					config.focusCoordinate.set(focusCoordinate);
+					config.showClosest.set(true);
+					message = "Light Level Overlay: Focus on: " + focusCoordinate;
+					messageRemainingTicks = 40;
+				} else {
+					config.focusCoordinate.set("");
+					config.showClosest.set(false);
+					message = "Light Level Overlay: Focus on: player";
+					messageRemainingTicks = 40;
+				}
 			} else if (!withShift && !withCtrl && !withAlt) {
 				active = !active;
 				launchPoller();

--- a/src/main/java/com/mmyzd/llor/LightLevelOverlayReloaded.java
+++ b/src/main/java/com/mmyzd/llor/LightLevelOverlayReloaded.java
@@ -130,6 +130,17 @@ public class LightLevelOverlayReloaded {
 				messageB.append(ii).append(": ").append(poller.counts[ii]).append(" -- ");
 			}
 			event.getRight().add(messageB.toString());
+			if(poller.closestPosX > Integer.MIN_VALUE) {
+				messageB = new StringBuilder();
+				messageB.append("x: ").append(poller.closestPosX).append(" y: ").append(poller.closestPosY).append(" z: ").append(poller.closestPosZ);
+				event.getRight().add(messageB.toString());
+				messageB = new StringBuilder();
+				Minecraft mc = Minecraft.getMinecraft();
+				messageB.append("x: ").append((int)mc.player.posX - poller.closestPosX)
+								.append(" y: ").append((int)mc.player.posY - poller.closestPosY)
+								.append(" z: ").append((int)mc.player.posZ - poller.closestPosZ);
+				event.getRight().add(messageB.toString());
+			}
 		}
 	}
 }

--- a/src/main/java/com/mmyzd/llor/LightLevelOverlayReloaded.java
+++ b/src/main/java/com/mmyzd/llor/LightLevelOverlayReloaded.java
@@ -140,6 +140,7 @@ public class LightLevelOverlayReloaded {
 								.append(" y: ").append((int)mc.player.posY - poller.closestPosY)
 								.append(" z: ").append((int)mc.player.posZ - poller.closestPosZ);
 				event.getRight().add(messageB.toString());
+				event.getRight().add("minY : " + poller.minimumY);
 			}
 		}
 	}

--- a/src/main/java/com/mmyzd/llor/OverlayPoller.java
+++ b/src/main/java/com/mmyzd/llor/OverlayPoller.java
@@ -52,6 +52,32 @@ public class OverlayPoller extends Thread {
 		int playerPosY = (int)Math.floor(mc.player.posY);
 		int playerChunkX = mc.player.chunkCoordX;
 		int playerChunkZ = mc.player.chunkCoordZ; 
+		
+		// when we have a constant starting position we override the player position here.
+		String constantCoordinate = LightLevelOverlayReloaded.instance.config.focusCoordinate.getString();
+		if(constantCoordinate != null && !constantCoordinate.isEmpty()) {
+			String[] constantCoordinates = constantCoordinate.split(",");
+			if(constantCoordinates.length == 3) {
+				int newX = Integer.MIN_VALUE;
+				int newY = Integer.MIN_VALUE;
+				int newZ = Integer.MIN_VALUE;
+				try {
+					newX = Integer.parseInt(constantCoordinates[0]);
+					newY = Integer.parseInt(constantCoordinates[1]);
+					newZ = Integer.parseInt(constantCoordinates[2]);
+				} catch (NumberFormatException nfex) {
+					// that didn't work.
+				}
+				if(newZ > Integer.MIN_VALUE) { // conversion worked
+					playerPosY = newY;
+					playerChunkX = (int)Math.floor(newX / 16.0);
+					playerChunkZ = (int)Math.floor(newZ / 16.0);
+				}
+				// x, y -> / 16 & floor
+				// z -> /256 & floor
+			} // else its bogus
+		}
+		
 		int skyLightSub = world.calculateSkylightSubtracted(1.0f);
 		int displayMode = LightLevelOverlayReloaded.instance.config.displayMode.getInt();
 		boolean useSkyLight = LightLevelOverlayReloaded.instance.config.useSkyLight.getBoolean();

--- a/src/main/java/com/mmyzd/llor/OverlayPoller.java
+++ b/src/main/java/com/mmyzd/llor/OverlayPoller.java
@@ -15,14 +15,21 @@ import net.minecraft.world.chunk.Chunk;
 
 public class OverlayPoller extends Thread {
 	
+	// the volatile only adresses the situation in which the chunk radius is changed
+	// TODO: consider rewriting the whole thing.
 	public volatile ArrayList<Overlay>[][] overlays;
 	
+	// counts is a new reference in each iteration, so its volitile-ness helps.
+	public volatile int[] counts = new int[8];
+	
+	@Override
 	public void run() {
 		int radius = 0;
 		while (true) {
 			int chunkRadius = updateChunkRadius();
 			radius = radius % chunkRadius + 1;
-			if (LightLevelOverlayReloaded.instance.active) updateLightLevel(radius, chunkRadius);
+			if (LightLevelOverlayReloaded.instance.active)
+				updateLightLevel(radius, chunkRadius);
 			try {
 				sleep(LightLevelOverlayReloaded.instance.config.pollingInterval.getInt());
 			} catch (Exception e) {
@@ -36,9 +43,10 @@ public class OverlayPoller extends Thread {
 		int size = LightLevelOverlayReloaded.instance.config.chunkRadius.getInt();
 		if (overlays == null || overlays.length != size * 2 + 1) {
 			overlays = new ArrayList[size * 2 + 1][size * 2 + 1];
+			
 			for (int i = 0; i < overlays.length; i++)
-			for (int j = 0; j < overlays[i].length; j++)
-				overlays[i][j] = new ArrayList<Overlay>();
+				for (int j = 0; j < overlays[i].length; j++)
+					overlays[i][j] = new ArrayList<Overlay>();
 		}
 		return size;
 	}
@@ -51,7 +59,8 @@ public class OverlayPoller extends Thread {
 		WorldClient world = mc.world;
 		int playerPosY = (int)Math.floor(mc.player.posY);
 		int playerChunkX = mc.player.chunkCoordX;
-		int playerChunkZ = mc.player.chunkCoordZ; 
+		int playerChunkZ = mc.player.chunkCoordZ;
+		boolean recountB = radius == chunkRadius; // only recount if all chunks are counted.
 		
 		// when we have a constant starting position we override the player position here.
 		String constantCoordinate = LightLevelOverlayReloaded.instance.config.focusCoordinate.getString();
@@ -82,61 +91,70 @@ public class OverlayPoller extends Thread {
 		int displayMode = LightLevelOverlayReloaded.instance.config.displayMode.getInt();
 		boolean useSkyLight = LightLevelOverlayReloaded.instance.config.useSkyLight.getBoolean();
 		
-		for (int chunkX = playerChunkX - radius; chunkX <= playerChunkX + radius; chunkX++)
-		for (int chunkZ = playerChunkZ - radius; chunkZ <= playerChunkZ + radius; chunkZ++) {
-			Chunk chunk = mc.world.getChunkFromChunkCoords(chunkX, chunkZ);
-			if (!chunk.isLoaded()) continue;
-			ArrayList<Overlay> buffer = new ArrayList<Overlay>();
-			for (int offsetX = 0; offsetX < 16; offsetX++)
-			for (int offsetZ = 0; offsetZ < 16; offsetZ++) {
-				int posX = (chunkX << 4) + offsetX;
-				int posZ = (chunkZ << 4) + offsetZ;
-				int maxY = playerPosY + 4, minY = Math.max(playerPosY - 40, 0);
-				IBlockState preBlockState = null, curBlockState = chunk.getBlockState(offsetX, maxY, offsetZ);
-				Block preBlock = null, curBlock = curBlockState.getBlock();
-				BlockPos prePos = null, curPos = new BlockPos(posX, maxY, posZ);
-				for (int posY = maxY - 1; posY >= minY; posY--) {
-					preBlockState = curBlockState;
-					curBlockState = chunk.getBlockState(offsetX, posY, offsetZ);
-					preBlock = curBlock;
-					curBlock = curBlockState.getBlock();
-					prePos = curPos;
-					curPos = new BlockPos(posX, posY, posZ);
-					if (curBlock == Blocks.AIR ||
-						curBlock == Blocks.BEDROCK ||
-						curBlock == Blocks.BARRIER ||
-						preBlockState.isBlockNormalCube() ||
-						preBlockState.getMaterial().isLiquid() ||
-						preBlockState.canProvidePower() ||
-						curBlockState.isSideSolid(world, curPos, EnumFacing.UP) == false ||
-						BlockRailBase.isRailBlock(preBlockState)) {
-						continue;
-					}
-					double offsetY = 0;
-					if (preBlock == Blocks.SNOW_LAYER || preBlock == Blocks.CARPET) {
-						offsetY = preBlockState.getBoundingBox(world, prePos).maxY;
-						if (offsetY >= 0.15) continue; // Snow layer too high
-					}
-					int blockLight = chunk.getLightFor(EnumSkyBlock.BLOCK, prePos);
-					int   skyLight = chunk.getLightFor(EnumSkyBlock.SKY, prePos) - skyLightSub;
-					int mixedLight = Math.max(blockLight, skyLight);
-					int lightIndex = useSkyLight ? mixedLight : blockLight;
-					if (displayMode == 1) {
-						if (mixedLight >= 8 && blockLight < 8) lightIndex += 32;
-					} else if (displayMode == 2) {
-						if (blockLight >= 8) continue;
-						if (lightIndex >= 8) lightIndex += 32;
-					}
-					if (lightIndex >= 8 && lightIndex < 24) lightIndex ^= 16;
-					buffer.add(new Overlay(posX, posY + offsetY + 1, posZ, lightIndex));
-				}
-			}
-			int len = chunkRadius * 2 + 1;
-			int arrayX = (chunkX % len + len) % len;
-			int arrayZ = (chunkZ % len + len) % len;
-			overlays[arrayX][arrayZ] = buffer;
+		int[] recount = new int[counts.length];
+		for(int ii = 0; ii < recount.length; ii++) {
+			recount[ii] = 0;
 		}
 		
+		for (int chunkX = playerChunkX - radius; chunkX <= playerChunkX + radius; chunkX++)
+			for (int chunkZ = playerChunkZ - radius; chunkZ <= playerChunkZ + radius; chunkZ++) {
+				Chunk chunk = mc.world.getChunkFromChunkCoords(chunkX, chunkZ);
+				if (!chunk.isLoaded()) continue;
+				ArrayList<Overlay> buffer = new ArrayList<Overlay>();
+				for (int offsetX = 0; offsetX < 16; offsetX++)
+					for (int offsetZ = 0; offsetZ < 16; offsetZ++) {
+						int posX = (chunkX << 4) + offsetX;
+						int posZ = (chunkZ << 4) + offsetZ;
+						int maxY = playerPosY + 4, minY = Math.max(playerPosY - 40, 0);
+						IBlockState preBlockState = null, curBlockState = chunk.getBlockState(offsetX, maxY, offsetZ);
+						Block preBlock = null, curBlock = curBlockState.getBlock();
+						BlockPos prePos = null, curPos = new BlockPos(posX, maxY, posZ);
+						for (int posY = maxY - 1; posY >= minY; posY--) {
+							preBlockState = curBlockState;
+							curBlockState = chunk.getBlockState(offsetX, posY, offsetZ);
+							preBlock = curBlock;
+							curBlock = curBlockState.getBlock();
+							prePos = curPos;
+							curPos = new BlockPos(posX, posY, posZ);
+							if (curBlock == Blocks.AIR ||
+								curBlock == Blocks.BEDROCK ||
+								curBlock == Blocks.BARRIER ||
+								preBlockState.isBlockNormalCube() ||
+								preBlockState.getMaterial().isLiquid() ||
+								preBlockState.canProvidePower() ||
+								curBlockState.isSideSolid(world, curPos, EnumFacing.UP) == false ||
+								BlockRailBase.isRailBlock(preBlockState)) {
+								continue;
+							}
+							double offsetY = 0;
+							if (preBlock == Blocks.SNOW_LAYER || preBlock == Blocks.CARPET) {
+								offsetY = preBlockState.getBoundingBox(world, prePos).maxY;
+								if (offsetY >= 0.15) continue; // Snow layer too high
+							}
+							int blockLight = chunk.getLightFor(EnumSkyBlock.BLOCK, prePos);
+							int   skyLight = chunk.getLightFor(EnumSkyBlock.SKY, prePos) - skyLightSub;
+							int mixedLight = Math.max(blockLight, skyLight);
+							int lightIndex = useSkyLight ? mixedLight : blockLight;
+							if (displayMode == 1) {
+								if (mixedLight >= 8 && blockLight < 8) lightIndex += 32;
+							} else if (displayMode == 2) {
+								if (blockLight >= 8) continue;
+								if (lightIndex >= 8) lightIndex += 32;
+							}
+							if (lightIndex >= 8 && lightIndex < 24) lightIndex ^= 16;
+							if(recountB && recount.length > lightIndex) // only count 8 and below.
+								recount[lightIndex] ++;
+							buffer.add(new Overlay(posX, posY + offsetY + 1, posZ, lightIndex));
+						}
+					}
+				
+				int len = chunkRadius * 2 + 1;
+				int arrayX = (chunkX % len + len) % len;
+				int arrayZ = (chunkZ % len + len) % len;
+				overlays[arrayX][arrayZ] = buffer;
+			}
+		if(recountB)
+			counts = recount;
 	}
 	
 }


### PR DESCRIPTION
Hi,

I wanted to build a MobSpawner and needed to clear the area of dark tiles so mobs only spawn in my Spawner. For that I extended your Mod to be able to set a fixed center of calculation and display the amount of dark tiles, as well as the directions to the closest one.

The feature is (de-)activated by STRL-SHIFT-Hotkey.
The UI is not incredibly 'nice' but works.

In case you don't want this, are you okay with me making a new mod based on yours with this feature?

Have fun!

Angelo