### PR TITLE
Overhaul of language files

### DIFF
--- a/src/main/resources/assets/llor/lang/en_us.json
+++ b/src/main/resources/assets/llor/lang/en_us.json
@@ -1,11 +1,11 @@
 {
-    "key.llor.toggle": "Toggle On/Off",
-    "key.llor.switch_mode": "Next display mode",
     "key.categories.llor": "Light Level Overlay Reloaded",
-    "llor.message.switch_mode": "Light Level Overlay: %s",
-    "llor.message.toggle_on": "Light Level Overlay: on",
-    "llor.message.toggle_off": "Light Level Overlay: off",
-    "llor.message.opening_error": "Light Level Overlay: failed to open %s",
-    "llor.message.parsing_error": "Light Level Overlay: failed to parse %s",
-    "llor.message.binding_error": "Light Level Overlay: failed to bind texture for %s"
+    "key.llor.toggle": "Toggle Overlay",
+
+    "llor.message.toggle_on": "Light Level Overlay Reloaded: Overlay enabled",
+    "llor.message.toggle_off": "Light Level Overlay Reloaded: Overlay disabled",
+    "llor.message.switch_mode": "Light Level Overlay Reloaded: %s mode",
+    "llor.message.opening_error": "Light Level Overlay Reloaded: Failed to open %s",
+    "llor.message.parsing_error": "Light Level Overlay Reloaded: Failed to parse %s",
+    "llor.message.binding_error": "Light Level Overlay Reloaded: Failed to bind texture for %s"
 }

--- a/src/main/resources/assets/llor/lang/sv_se.json
+++ b/src/main/resources/assets/llor/lang/sv_se.json
@@ -1,11 +1,11 @@
 {
-    "key.llor.toggle": "Sätt På/Av",
-    "key.llor.switch_mode": "Nästa visningsläge",
     "key.categories.llor": "Light Level Overlay Reloaded",
-    "llor.message.switch_mode": "Light Level Overlay: %s",
-    "llor.message.toggle_on": "Light Level Overlay: på",
-    "llor.message.toggle_off": "Light Level Overlay: av",
-    "llor.message.opening_error": "Light Level Overlay: Misslyckades med att öppna %s",
-    "llor.message.parsing_error": "Light Level Overlay: failed to parse %s",
-    "llor.message.binding_error": "Light Level Overlay: Misslyckades med att binda textur för %s"
+    "key.llor.toggle": "Sätt På/Av",
+
+    "llor.message.toggle_on": "Light Level Overlay Reloaded: på",
+    "llor.message.toggle_off": "Light Level Overlay Reloaded: av",
+    "llor.message.switch_mode": "Light Level Overlay Reloaded: %s läge",
+    "llor.message.opening_error": "Light Level Overlay Reloaded: Misslyckades med att öppna %s",
+    "llor.message.parsing_error": "Light Level Overlay Reloaded: Failed to parse %s",
+    "llor.message.binding_error": "Light Level Overlay Reloaded: Misslyckades med att binda textur för %s"
 }

--- a/src/main/resources/assets/llor/lang/tr_tr.json
+++ b/src/main/resources/assets/llor/lang/tr_tr.json
@@ -1,11 +1,11 @@
 {
-    "key.llor.toggle": "Aç/Kapa",
-    "key.llor.switch_mode": "Bir sonraki ekran modu",
     "key.categories.llor": "Light Level Overlay Reloaded",
-    "llor.message.switch_mode": "Işık Seviyesi Gösterimi: %s",
-    "llor.message.toggle_on": "Işık Seviyesi Gösterimi: açık",
-    "llor.message.toggle_off": "Işık Seviyesi Gösterimi: kapalı",
-    "llor.message.opening_error": "Işık Seviyesi Gösterimi: %s açılamadı",
-    "llor.message.parsing_error": "Işık Seviyesi Gösterimi: %s ayrıştırması başarısız",
-    "llor.message.binding_error": "Işık Seviyesi Gösterimi: %s için doku ataması başarısız"
+    "key.llor.toggle": "Aç/Kapa",
+
+    "llor.message.toggle_on": "Light Level Overlay Reloaded: açık",
+    "llor.message.toggle_off": "Light Level Overlay Reloaded: kapalı",
+    "llor.message.switch_mode": "Light Level Overlay Reloaded: %s modu",
+    "llor.message.opening_error": "Light Level Overlay Reloaded: %s açılamadı",
+    "llor.message.parsing_error": "Light Level Overlay Reloaded: %s ayrıştırması başarısız",
+    "llor.message.binding_error": "Light Level Overlay Reloaded: %s için doku ataması başarısız"
 }

--- a/src/main/resources/assets/llor/lang/zh_cn.json
+++ b/src/main/resources/assets/llor/lang/zh_cn.json
@@ -1,11 +1,11 @@
 {
+    "key.categories.llor": "Light Level Overlay Reloaded",
     "key.llor.toggle": "开/关光照提示",
-    "key.llor.switch_mode": "切换至下一个显示模式",
-    "key.categories.llor": "Light Level Overlay Reloaded"
-    "llor.message.switch_mode": "光照提示: %s",
-    "llor.message.toggle_on": "光照提示: 开启",
-    "llor.message.toggle_off": "光照提示: 关闭",
-    "llor.message.opening_error": "光照提示: 无法访问 %s",
-    "llor.message.parsing_error": "光照提示: 无法解析 %s",
-    "llor.message.binding_error": "光照提示: 无法为 %s 绑定贴图"
+
+    "llor.message.toggle_on": "Light Level Overlay Reloaded: 开启",
+    "llor.message.toggle_off": "Light Level Overlay Reloaded: 关闭",
+    "llor.message.switch_mode": "Light Level Overlay Reloaded: %s 模式",
+    "llor.message.opening_error": "Light Level Overlay Reloaded: 无法访问 %s",
+    "llor.message.parsing_error": "Light Level Overlay Reloaded: 无法解析 %s",
+    "llor.message.binding_error": "Light Level Overlay Reloaded: 无法为 %s 绑定贴图"
 }


### PR DESCRIPTION
In this commit I made several changes in all language files, and the most notable ones include:
* addition of a missing comma at the end of a line in the Chinese language file
* addition of one empty line between strings related to keys and those related to statements
* movement of the key group "Light Level Overlay Reloaded" above all strings related to keys
* change of "Light Level Overlay" to "Light Level Overlay Reloaded", as now this is the proper mod name
* removal of `key.llor.switch_mode`, as it is no longer used.